### PR TITLE
EMP, PowerUp-Prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,23 +25,47 @@ https://trello.com/b/2Vm2EXmP/shotz
 * designs for each ship (just change one specific triangle every time)
 
 
-## Update Jan 10.02.2020
-Bullet überarbeitet:
-  * Funktion shoot() in ship.js eingeführt - jetzt lässt sich das shot delay millisekundenweise
-    steuern (z.b. shoot(500); bedeutet 2 Schuss pro Sekunde)
-  * Bullets haben jetzt vier Parameter:
-     * Das Schiff, das den Schuss abgegeben hat (als Referenz)
-     * Die Farbe der Bullet
-     * Die Schussrichtung
-     * Den Schuss-Startpunkt (falls ships später mehrere Kanonen haben)
-  * Bulletanimation ist jetzt (mittels p5.deltaTime) unabhängig von Framerate (-> auch in ship- und enemy-Animation einfügen?!)
-    Die Variable dt wird jetzt in main.js berechnet, die als Faktor zur Framerate-Kontrolle verwendet werden kann
-  * Laser (Bullet-Type) hinzugefügt
+## Update Jan 03.03.2020
+- Ship.collides() hinzugefügt = check, ob Ship mit Gegner kollidiert ist.
 
-  * Laser angepasst: dmg--, bulletspeed+++
-  * shoots()-Funktion jetzt generischer für verschiedene Bullets und delays
-  * Ship beispielhaft mit 3 verschiedenen Schüssen ausgestattet
+- EMP eingefügt (wie in Trello beschrieben, mit Ship.emp() und Enemy.push()) - dazu
+  habe ich die enemy location auf Vector umgestellt (this.pos.x, statt this.x) und
+  das update dieser location aufgeräumt. Die Taste "R" löst den emp() nicht direkt aus,
+  sondern setzt ship.empActive auf true. Der Rest passiert dann automatisch.
 
-## TODO:
-* Scaling by window.resize
-* EnemyType "SpikeOrbitter" abgeschlossen (ohne extends Enemy)
+- PowerUp-Prototyp eingefügt:
+    Einziges Augenmerk bisher auf Funktionalität und Skalierbarkeit - nicht beachtet wurden:
+        * Balancing
+        * Kreativität (sowohl der PUs, als auch der Darstellung der Pickups)
+        * Dropwahrscheinlichkeit PUs zu hoch (besser überprüfbar, während dev -
+          aktuell Enemy.dropChance = 0.9 = 90%)
+        * Bisher nur Stat-Ups, keine komplexeren (deshalb bisher überall in
+          powerups.js mods:null)
+
+    Programmablauf PU:
+        0. Alle Powerups werden als Objekt in powerups.js gespeichert (bisher 5)
+        1. On Enemy-kill (per Bullet oder Crash): Check ob random(1) > Enemy.dropChance
+        2. Falls Check erfolgreich: game.choosePowerUp() - nimmt ein zufälliges PU
+           aus powerups-Objekt in powerups.js und fügt es ship.mods[] als type:'pickup' hinzu
+        3. In Ship.update() wird geprüft, ob ein 'pickup'-Objekt in Ship.mods
+           enthalten ist - wenn ja: mod.draw()
+        4. mod.draw() verweist an game.drawPickup(), das auch die Logik zum
+           Einsammeln und MouseOver enthält (und, perspektivisch, das timeout)
+        5. Wenn Spieler ein pickup einsammelt, wird mod.onPickup() ausgelöst
+           (Stat+ oder dauerhaftes Mod an Ship.mods senden)
+
+    Vorteile:
+        * Weitere PowerUps können in einem einheitlichen Format, an einer zentralen
+          Stelle ohne zusätzliche Logik eingefügt werden
+        * Sobald ein neues PU auf diese Weise eingefügt wurde, wird es automatisiert
+          mit in den Prozess (Programmablauf) einbezogen
+        * Skalierbar (auch komplexere PUs in diesem Format möglich)
+
+    Was fehlt:
+        * Fix Health-bar und MaxHealth des Schiffes
+        * Balancing der PUs (dropChance vs. Effektstärke)
+        * Überarbeitung des Löschens von PUs beim Einsammeln - bisher verschwinden
+          vereinzelt pickups, wenn zuvor mehrere auf dem Screen waren (evtl. uuid
+          für PUs erstellen, damit eindeutiger Zugriff möglich ist?!)
+        * Lösung für Timeout finden (Entfernen des Pickups vom Screen, wenn
+          Spieler es zu lange nicht einsammelt - 5Sek?)

--- a/bullet.js
+++ b/bullet.js
@@ -20,6 +20,13 @@ show() {
     pop();
 }
 
+// onHit() {
+//     // Event driven effect. Is filled by powerUps-object
+//     this.mods_onHit.forEach((m) => {
+//         m(); // m mit () führt die übergebene Funktionsreferenz aus.
+//     });
+// }
+
 update() {
     this.vel.setMag(this.speed * this.shooter.bulletspeed);
     this.pos.add(p5.Vector.mult(this.vel, dt)); // anstatt this.pos.add(this.vel) - für framerate control

--- a/enemy.js
+++ b/enemy.js
@@ -8,11 +8,13 @@ constructor(color) {
     this.color = color;                                 // = @param: Farbe von Lvl vorgegeben
 
     this.vel = createVector(random(-10,10), random(-10, 10)).normalize();
-    this.x = 0;
-    this.y = 0;
+    this.pos = createVector(0, 0);
+
     this.setStartSpot();                    // = Startlocation
 
     this.score = 5;                         // = Player-points per Kill
+    this.dropChance = 0.9;                  // = Chance, dass powerUp fallen gelassen wird
+    this.knockbackSensitivity = 1           // = Multiplier für Knockback-Vektor
     this.chase = false;
     this.lock = false;
 }
@@ -21,62 +23,68 @@ setStartSpot() {
     let s = floor(random(4));
     // still kills you in corners (would say that's fine)
     if (s == 0) {
-        this.x = this.size/2;
-        this.y = random(this.size/2, height - this.size/2);
+        this.pos.x = this.size/2;
+        this.pos.y = random(this.size/2, height - this.size/2);
     } else if (s == 1) {
-        this.x = width - this.size/2;
-        this.y = random(this.size/2, height - this.size/2);
+        this.pos.x = width - this.size/2;
+        this.pos.y = random(this.size/2, height - this.size/2);
     } else if (s == 2) {
-        this.x = random(this.size/2, width - this.size/2);
-        this.y = this.size/2;
+        this.pos.x = random(this.size/2, width - this.size/2);
+        this.pos.y = this.size/2;
     } else {
-        this.x = random(this.size/2, width - this.size/2);
-        this.y = height - this.size/2;
+        this.pos.x = random(this.size/2, width - this.size/2);
+        this.pos.y = height - this.size/2;
     }
 
-    if (dist(game.screen.ship.x, game.screen.ship.y, this.x, this.y) < this.size) {
+    if (dist(game.screen.ship.x, game.screen.ship.y, this.pos.x, this.pos.y) < this.size) {
         this.setStartSpot();
     }
 }
 
 show() {
     fill(this.color);
-    ellipse(this.x, this.y, this.size);
+    ellipse(this.pos.x, this.pos.y, this.size);
 }
 
 update() {
-    // calls this.show() as last step of update
-    for (let i = 0; i < game.screen.ship.vectors.length; i++) {
-        // check enemy collision with isHit() for each vector
-        let vx = game.screen.ship.vectors[i].x + game.screen.ship.x;
-        let vy = game.screen.ship.vectors[i].y + game.screen.ship.y;
-        if (this.isHit(createVector(vx, vy))) {
-            // Check with Server
-            // Diesen Gegner aus Liste entfernen
-            game.screen.enemies.splice(game.screen.enemies.indexOf(this), 1);
-            // Kollision Schiff/Gegner überarbeiten! Abhängig davon womit das Schiff den Gegner trifft, werden ggf. mehrere Lebenspunkte abgezogen. (manche Vektoren doppelt gechecked?)
-            if (game.screen.ship.PlayerHP > 1) {
-                game.screen.ship.PlayerHP--;
-            } else {
-                game.screen.ship.PlayerHP = 0;
-                game.screen.end();
-                return;
-            }
+    if (game.screen.ship.collides(this)) {
+        // Check with Server
+        // Diesen Gegner aus Liste entfernen
+        if (random(1) < this.dropChance) {
+            game.choosePowerUp(this.pos.x, this.pos.y);
+        }
+        game.screen.enemies.splice(game.screen.enemies.indexOf(this), 1);
+        // Kollision Schiff/Gegner überarbeiten! Abhängig davon womit das Schiff den Gegner trifft, werden ggf. mehrere Lebenspunkte abgezogen. (manche Vektoren doppelt gechecked?)
+        if (game.screen.ship.PlayerHP > 1) {
+            game.screen.ship.PlayerHP--;
+        } else {
+            game.screen.ship.PlayerHP = 0;
+            game.screen.end();
+            return;
         }
     }
 
-    this.x = this.x + this.vel.x * this.speed;
-    this.y = this.y + this.vel.y * this.speed;
-
-    if (this.x < this.size/2) {
-        this.vel = createVector(random(1,10), random(-10, 10));
-    } else if (this.x > width - this.size/2) {
-        this.vel = createVector(random(-10,-1), random(-10, 10));
-    } else if (this.y < this.size/2) {
-        this.vel = createVector(random(-10,10), random(1, 10));
-    } else if (this.y > height - this.size/2) {
-        this.vel = createVector(random(-10,10), random(-1, -10));
+    let angle;
+    if (this.pos.x < this.size/2) {
+        this.pos.x = this.size/2;
+        angle = random(180) - 90;
+        this.vel.rotate(angle);
+    } else if (this.pos.x > width - this.size/2) {
+        this.pos.x = width - this.size/2;
+        angle = random(180) + 90;
+        this.vel.rotate(angle);
+    } else if (this.pos.y < this.size/2) {
+        this.pos.y = this.size/2;
+        angle = random(180);
+        this.vel.rotate(angle);
+    } else if (this.pos.y > height - this.size/2) {
+        this.pos.y = height - this.size/2;
+        angle = random(180) + 180;
+        this.vel.rotate(angle);
     }
+
+    this.vel.mult(this.speed);
+    this.pos.add(this.vel);
     this.vel.normalize();
     this.show();
 }
@@ -86,6 +94,9 @@ handleHit(bullet) {
         this.size -= bullet.damage;
     } else {
         game.screen.score += this.score;
+        if (random(1) < this.dropChance) {
+            game.choosePowerUp(this.pos.x, this.pos.y);
+        }
         // Diesen Gegner aus Liste entfernen
         game.screen.enemies.splice(game.screen.enemies.indexOf(this), 1);
     }
@@ -96,11 +107,11 @@ isHit(obj) {
     let hit = false;
 
     if (obj instanceof Bullet) {
-        if (dist(obj.pos.x, obj.pos.y, this.x, this.y) < this.size/2 + obj.size/2) {
+        if (dist(obj.pos.x, obj.pos.y, this.pos.x, this.pos.y) < this.size/2 + obj.size/2) {
             hit = true;
         }
     } else if (obj instanceof p5.Vector) {
-        if (dist(obj.x, obj.y, this.x, this.y) < this.size/2) hit = true;
+        if (dist(obj.x, obj.y, this.pos.x, this.pos.y) < this.size/2) hit = true;
     }
 
     return hit;
@@ -110,6 +121,17 @@ isDead(dmg) {
     // returns true, if given amount of dmg reduces life to or below zero
     if (this.size - dmg <= this.minsize) return true;
     else return false;
+}
+
+push(vector, duration, timestamp) {
+    let vec = vector.mult(this.knockbackSensitivity);
+    if (duration) {
+       if (millis() <= timestamp + duration) {
+           this.vel.add(vec);
+       }
+   } else {   // Wenn kein duration gegeben, instant push
+       this.vel.add(vec);
+   }
 }
 }
 

--- a/game.js
+++ b/game.js
@@ -27,4 +27,90 @@ controls(mode) {
     }
     this.screen.controls(mode);
 }
+
+choosePowerUp(x, y) {
+    // Chooses one powerup from powerups-object randomly and pushes it to ship.mods
+    let pu = powerups[Math.floor(Math.random()*powerups.length)];
+    this.screen.ship.mods.push({
+        type: 'pickup',
+        draw: this.wrapDraw(x, y, pu),
+        onPickup: this.wrapOnPickup(pu),
+        timestamp: millis()
+    });
+}
+
+wrapDraw(x, y, pu) {
+    // wraps draw() for context variables/parameter
+    return function() {pu.pickup.draw(x, y, pu)};
+}
+
+wrapOnPickup(pu) {
+    // wraps onPickup() for context variables/parameter
+    return function() {pu.pickup.onPickup(pu)};
+}
+
+drawPickup(x, y, pu, content) {
+    /*
+    *  Parameter:
+    *  x, y:    Position des getöteten Gegners (dort wird pickup dargestellt)
+    *  pu:      Referenz zum richtigen PowerUp-Objekt
+    *  content: Aussehen des pickups (innerhalb des gelben Rahmens - bisher nur Buchstabenkürzel)
+    */
+
+    // Aussehen Pickups
+    push();
+        strokeWeight(4);
+        fill(0, 0, 0, 100);
+        stroke(255, 204, 0);
+        rect(x, y, 60, 60);
+        rect(x-5, y-5, 70, 70);
+        content();
+    pop();
+
+    // Schiffkolission zum Einsammeln des Pickups
+    game.screen.ship.vectors.forEach((v) => {
+        const vx = v.x + game.screen.ship.x;
+        const vy = v.y + game.screen.ship.y;
+        if (vx >= x && vx <= x+60 && vy >= y && vy <= y+60) {
+            pu.pickup.onPickup(pu);
+        }
+    });
+
+    // Beschreibungstext onMouseOver anzeigen
+    if (mouseX >= x && mouseX <= x+60 && mouseY >= y && mouseY <= y+60) {
+        let pos_hor = 0;
+        let pos_ver = 0;
+        if (mouseX > width/2) pos_hor = -300;
+        else pos_hor = 60;
+        if (mouseY > height/2) pos_ver = -60;
+        else pos_ver = 60;
+
+        push();
+            strokeWeight(2);
+            fill(0, 0, 0, 100);
+            stroke(255, 204, 0);
+            rect(x+pos_hor, y+pos_ver, 300, 60);
+
+            textSize(15);
+            fill('red');
+            noStroke();
+            text(pu.pickup.description, x+pos_hor+10, y+pos_ver+5, 280, 50);
+        pop();
+    }
+    //
+    // // Löschen der Pickups nach 5 Sekunden
+    // console.log(game.screen.ship.mods.indexOf(pu.pickup));
+    // let index = game.screen.ship.mods.indexOf(pu.pickup);
+    // console.log(index);
+    // console.log(game.screen.ship.mods[index]);
+    // console.log(game.screen.ship.mods[index].timestamp);
+    // // console.log(pu.pickup.timestamp);
+    // // console.log(typeof pu.pickup.timestamp);
+    // // console.log(millis());
+    // // console.log(pu.pickup.timestamp - (millis()-5000));
+    // if (pu.pickup.timestamp < millis()-5000) {
+    //     game.screen.ship.mods.splice(game.screen.ship.mods.indexOf(pu.pickup), 1);
+    // }
+    }
+
 }

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     <script src="ship.js"></script>
     <script src="enemy.js"></script>
     <script src="bullet.js"></script>
+    <script src="powerups.js"></script>
   </head>
   <body>
   </body>

--- a/item.js
+++ b/item.js
@@ -219,6 +219,7 @@ this.activeCounter = this.activeTime;
                 this.amount--;
             }
             //schubst gegner weg/hebt chase auf etc
+            game.screen.ship.empActive = true;
             break;
         case "SPC":
             game.screen.ship.special();

--- a/powerups.js
+++ b/powerups.js
@@ -1,0 +1,118 @@
+// Hier werden alle PowerUps in einem Objekt gesammelt
+
+const powerups = [
+    {
+        name: 'hpUP',
+        count: 'multiple',  // Wie oft kann es eingesammelt werden? unique/multiple
+        pickup: {           // Alles zum sammelbaren Icon
+            name: 'hpUP',
+            type: 'pickup',
+            description: 'Erhöht die Lebenspunkte des Schiffs um 2.',
+            onPickup: (pu) => {
+                game.screen.ship.PlayerHP += 2;
+                game.screen.ship.mods.splice(game.screen.ship.mods.indexOf(pu.pickup), 1);
+            },
+            draw: (x, y, pu) => {
+                let content = () => {
+                    textSize(25);
+                    text("HP+", x+5, y+30);
+                }
+                game.drawPickup(x, y, pu, content);
+            }
+        },
+        mod: null
+    },
+    {
+        name: 'damageUP',
+        count: 'multiple',  // Wie oft kann es eingesammelt werden? unique/multiple
+        pickup: {           // Alles zum sammelbaren Icon
+            name: 'damageUP',
+            type: 'pickup',
+            description: 'Erhöht den Schaden des Schiffes um 20%.',
+            onPickup: (pu) => {
+                game.screen.ship.PlayerDMG *= 1.2;
+                game.screen.ship.mods.splice(game.screen.ship.mods.indexOf(pu.pickup), 1);
+            },
+            draw: (x, y, pu) => {
+                // hier wird das Aussehen des pickups (innerhalb des Vierecks) an game.drawPickup() übergeben
+                let content = () => {
+                    // Aktuelle nur kurze Textzüge, kann aber durch komplexere Grafiken ersetzt werden.
+                    textSize(20);
+                    text("DMG+", x+5, y+30);
+                }
+                game.drawPickup(x, y, pu, content);
+            }
+        },
+        mod: null
+    },
+    {
+        name: 'SpeedUP',
+        count: 'multiple',  // Wie oft kann es eingesammelt werden? unique/multiple
+        pickup: {           // Alles zum sammelbaren Icon
+            name: 'SpeedUP',
+            type: 'pickup',
+            description: 'Erhöht die Bewegungsgeschwindigkeit des Schiffes.',
+            onPickup: (pu) => {
+                game.screen.ship.PlayerSPD += 1;
+                game.screen.ship.mods.splice(game.screen.ship.mods.indexOf(pu.pickup), 1);
+            },
+            draw: (x, y, pu) => {
+                // hier wird das Aussehen des pickups (innerhalb des Vierecks) an game.drawPickup() übergeben
+                let content = () => {
+                    textSize(20);
+                    text("SPD+", x+5, y+30);
+                }
+                game.drawPickup(x, y, pu, content);
+            }
+        },
+        mod: null
+    },
+    {
+        name: 'BulletspeedUP',
+        count: 'multiple',  // Wie oft kann es eingesammelt werden? unique/multiple
+        pickup: {           // Alles zum sammelbaren Icon
+            name: 'BulletspeedUP',
+            type: 'pickup',
+            description: 'Erhöht Projektilgeschwindigkeit und Reichweite.',
+            onPickup: (pu) => {
+                game.screen.ship.bulletspeed += 0.1;
+                game.screen.ship.PlayerRNG += 50;
+                game.screen.ship.mods.splice(game.screen.ship.mods.indexOf(pu.pickup), 1);
+            },
+            draw: (x, y, pu) => {
+                // hier wird das Aussehen des pickups (innerhalb des Vierecks) an game.drawPickup() übergeben
+                let content = () => {
+                    textSize(25);
+                    text("BS+", x+5, y+30);
+                }
+                game.drawPickup(x, y, pu, content);
+            }
+        },
+        mod: null
+    },
+    {
+        name: 'shotDelayDOWN',
+        count: 'multiple',  // Wie oft kann es eingesammelt werden? unique/multiple
+        pickup: {           // Alles zum sammelbaren Icon
+            name: 'shotDelayDOWN',
+            type: 'pickup',
+            description: 'Erhöht die Feuerrate.',
+            onPickup: (pu) => {
+                game.screen.ship.shotDelay *= 0.95;
+                console.log(pu.pickup);
+                // console.log(game.screen.ship.mods[game.screen.ship.mods.indexOf(pu.pickup)]);
+                console.log(game.screen.ship.mods.indexOf(pu.pickup));
+                game.screen.ship.mods.splice(game.screen.ship.mods.indexOf(pu.pickup), 1);
+            },
+            draw: (x, y, pu) => {
+                // hier wird das Aussehen des pickups (innerhalb des Vierecks) an game.drawPickup() übergeben
+                let content = () => {
+                    textSize(20);
+                    text("RoF+", x+5, y+30);
+                }
+                game.drawPickup(x, y, pu, content);
+            }
+        },
+        mod: null
+    },
+]

--- a/user.js
+++ b/user.js
@@ -16,7 +16,7 @@ new Item(3, "ammo3", 0, 3, color(0,255,0), 51, 0, 0),
 new Item(4, "ammo4", 1000, 4, color(0), 52, 0, 0),
 new Item(5, "ammo5", 1000, 2.5, color(255, 255, 75), 53, -1, 0),
 new Item(6, "ISH", 10, 0, color(0, 255, 255), 69, 1, 120),
-new Item(7, "EMP", 20, 0, color(255, 255, 200), 82, 0.2, 120),
+new Item(7, "EMP", 20, 0, color(255, 255, 200), 82, 0.2, 30),
 new Item(8, "MINE", 100, 100, color(200, 0,0 ), 84, 0.2, 60),
 new Item(9, "SPC", -1, 10, color(255, 255, 0), 70, 1, 60),
 new Item(10, "DASH", -1, 10, color(255), 81, 0.2, 30)


### PR DESCRIPTION
- Ship.collides() hinzugefügt = check, ob Ship mit Gegner kollidiert ist.

- EMP eingefügt (wie in Trello beschrieben, mit Ship.emp() und Enemy.push()) - dazu
  habe ich die enemy location auf Vector umgestellt (this.pos.x, statt this.x) und
  das update dieser location aufgeräumt. Die Taste "R" löst den emp() nicht direkt aus,
  sondern setzt ship.empActive auf true. Der Rest passiert dann automatisch.

- PowerUp-Prototyp eingefügt:
    Einziges Augenmerk bisher auf Funktionalität und Skalierbarkeit - nicht beachtet wurden:
        * Balancing
        * Kreativität (sowohl der PUs, als auch der Darstellung der Pickups)
        * Dropwahrscheinlichkeit PUs zu hoch (besser überprüfbar, während dev -
          aktuell Enemy.dropChance = 0.9 = 90%)
        * Bisher nur Stat-Ups, keine komplexeren (deshalb bisher überall in
          powerups.js mods:null)

    Programmablauf PU:
        0. Alle Powerups werden als Objekt in powerups.js gespeichert (bisher 5)
        1. On Enemy-kill (per Bullet oder Crash): Check ob random(1) > Enemy.dropChance
        2. Falls Check erfolgreich: game.choosePowerUp() - nimmt ein zufälliges PU
           aus powerups-Objekt in powerups.js und fügt es ship.mods[] als type:'pickup' hinzu
        3. In Ship.update() wird geprüft, ob ein 'pickup'-Objekt in Ship.mods
           enthalten ist - wenn ja: mod.draw()
        4. mod.draw() verweist an game.drawPickup(), das auch die Logik zum
           Einsammeln und MouseOver enthält (und, perspektivisch, das timeout)
        5. Wenn Spieler ein pickup einsammelt, wird mod.onPickup() ausgelöst
           (Stat+ oder dauerhaftes Mod an Ship.mods senden)

    Vorteile:
        * Weitere PowerUps können in einem einheitlichen Format, an einer zentralen
          Stelle ohne zusätzliche Logik eingefügt werden
        * Sobald ein neues PU auf diese Weise eingefügt wurde, wird es automatisiert
          mit in den Prozess (Programmablauf) einbezogen
        * Skalierbar (auch komplexere PUs in diesem Format möglich)

    Was fehlt:
        * Fix Health-bar und MaxHealth des Schiffes
        * Balancing der PUs (dropChance vs. Effektstärke)
        * Überarbeitung des Löschens von PUs beim Einsammeln - bisher verschwinden
          vereinzelt pickups, wenn zuvor mehrere auf dem Screen waren (evtl. uuid
          für PUs erstellen, damit eindeutiger Zugriff möglich ist?!)
        * Lösung für Timeout finden (Entfernen des Pickups vom Screen, wenn
          Spieler es zu lange nicht einsammelt - 5Sek?)